### PR TITLE
IPv4 queries for longer than /8 prefixes

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -9,7 +9,7 @@ description = """RDAP Bootstrap Server"""
 sourceCompatibility = 1.6
 targetCompatibility = 1.6
 
-
+apply plugin: 'eclipse'
 
 repositories {
         
@@ -20,4 +20,8 @@ dependencies {
     compile group: 'com.googlecode.java-ipv6', name: 'java-ipv6', version:'0.13'
     providedCompile group: 'javax.servlet', name: 'javax.servlet-api', version:'3.0.1'
     compile group: 'com.fasterxml.jackson.core', name: 'jackson-databind', version:'2.2.0'
+}
+
+dependencies {
+	compile group: 'net.ripe.ipresource', name: 'ipresource', version:'1.46'
 }

--- a/src/main/java/net/arin/rdap_bootstrap/service/IpV4Bootstrap.java
+++ b/src/main/java/net/arin/rdap_bootstrap/service/IpV4Bootstrap.java
@@ -16,84 +16,99 @@
  */
 package net.arin.rdap_bootstrap.service;
 
+import java.util.HashMap;
+import java.util.Set;
+
 import net.arin.rdap_bootstrap.service.JsonBootstrapFile.ServiceUrls;
 import net.arin.rdap_bootstrap.service.ResourceFiles.BootFiles;
-
-import java.util.HashMap;
+import net.ripe.ipresource.IpRange;
+import net.ripe.ipresource.UniqueIpResource;
 
 /**
  * @version $Rev$, $Date$
  */
-public class IpV4Bootstrap implements JsonBootstrapFile.Handler
-{
-    private volatile HashMap<Integer,ServiceUrls> allocations = new HashMap<Integer, ServiceUrls>(  );
-    private HashMap<Integer,ServiceUrls> _allocations;
+public class IpV4Bootstrap implements JsonBootstrapFile.Handler {
+	private volatile HashMap<String, ServiceUrls> allocations = new HashMap<String, ServiceUrls>();
+	private HashMap<String, ServiceUrls> _allocations; 
 
-    private ServiceUrls serviceUrls;
-    private String publication;
-    private String description;
+	private ServiceUrls serviceUrls;
+	private String publication;
+	private String description;
 
-    public void loadData( ResourceFiles resourceFiles )
-        throws Exception
-    {
-        JsonBootstrapFile bsFile = new JsonBootstrapFile();
-        bsFile.loadData( resourceFiles.getInputStream( BootFiles.V4.getKey() ), this );
-    }
+	public void loadData(ResourceFiles resourceFiles) throws Exception {
+		JsonBootstrapFile bsFile = new JsonBootstrapFile();
+		bsFile.loadData(resourceFiles.getInputStream(BootFiles.V4.getKey()), this);
+	}
 
-    @Override
-    public void startServices()
-    {
-        _allocations = new HashMap<Integer, ServiceUrls>(  );
-    }
+	@Override
+	public void startServices() {
+		_allocations = new HashMap<String, ServiceUrls>();
+	}
 
-    @Override
-    public void endServices()
-    {
-        allocations = _allocations;
-    }
+	@Override
+	public void endServices() {
+		allocations = _allocations;
+	}
 
-    @Override
-    public void startService()
-    {
-        serviceUrls = new ServiceUrls();
-    }
+	@Override
+	public void startService() {
+		serviceUrls = new ServiceUrls();
+	}
 
-    @Override
-    public void endService()
-    {
-        //nothing to do
-    }
+	@Override
+	public void endService() {
+		// nothing to do
+	}
 
-    @Override
-    public void addServiceEntry( String entry )
-    {
-        int key = Integer.parseInt( entry.split( "/" )[0].split( "\\." )[0] );
-        _allocations.put( key, serviceUrls );
-    }
+	@Override
+	public void addServiceEntry(String entry) {
+		_allocations.put(entry, serviceUrls);
+	}
 
-    @Override
-    public void addServiceUrl( String url )
-    {
-        serviceUrls.addUrl( url );
-    }
+	@Override
+	public void addServiceUrl(String url) {
+		serviceUrls.addUrl(url);
+	}
 
-    public ServiceUrls getServiceUrls( int prefix )
-    {
-        return allocations.get( prefix );
-    }
+	public ServiceUrls getServiceUrls(String prefix) {
+		
+		UniqueIpResource start;
+		try {
+			// /8 single int behaviour
+			new Integer(prefix);
+			start = IpRange.parse(prefix + ".0.0.0/8").getStart();
+		} catch (NumberFormatException e) {
+			start = IpRange.parse(prefix).getStart();
+		}
+		
+		ServiceUrls resultUrl = null;
+		IpRange resultNetwork = IpRange.parse("0.0.0.0/0");
+		final Set<String> keys = allocations.keySet();
+		for (String key : keys) {
+			final IpRange network = IpRange.parse(key);
+			if(network.contains(start) && (resultNetwork.getPrefixLength() < network.getPrefixLength())) {
+				resultNetwork = network;
+				resultUrl = allocations.get(key);
+			}
+		}
+		return resultUrl;
+	}
 
-    @Override
-    public void setPublication( String publication ) { this.publication = publication; }
-    public String getPublication() { return publication; }
+	@Override
+	public void setPublication(String publication) {
+		this.publication = publication;
+	}
 
-    public String getDescription()
-    {
-        return description;
-    }
+	public String getPublication() {
+		return publication;
+	}
 
-    @Override
-    public void setDescription( String description )
-    {
-        this.description = description;
-    }
+	public String getDescription() {
+		return description;
+	}
+
+	@Override
+	public void setDescription(String description) {
+		this.description = description;
+	}
 }

--- a/src/main/java/net/arin/rdap_bootstrap/service/IpV4Bootstrap.java
+++ b/src/main/java/net/arin/rdap_bootstrap/service/IpV4Bootstrap.java
@@ -73,11 +73,21 @@ public class IpV4Bootstrap implements JsonBootstrapFile.Handler {
 	public ServiceUrls getServiceUrls(String prefix) {
 		
 		UniqueIpResource start;
-		try {
+		
+		if(!prefix.contains("/") && prefix.contains(".")) {
+			// single host
+			start = UniqueIpResource.parse(prefix);
+		} else if (!prefix.contains("/")) {
 			// /8 single int behaviour
-			new Integer(prefix);
-			start = IpRange.parse(prefix + ".0.0.0/8").getStart();
-		} catch (NumberFormatException e) {
+			try {
+				new Integer(prefix);
+				start = IpRange.parse(prefix + ".0.0.0/8").getStart();
+			} catch (NumberFormatException e) {
+				// network
+				start = IpRange.parse(prefix).getStart();
+			}
+		} else {
+			// network
 			start = IpRange.parse(prefix).getStart();
 		}
 		

--- a/src/main/java/net/arin/rdap_bootstrap/service/IpV6Bootstrap.java
+++ b/src/main/java/net/arin/rdap_bootstrap/service/IpV6Bootstrap.java
@@ -16,18 +16,14 @@
  */
 package net.arin.rdap_bootstrap.service;
 
-import com.googlecode.ipv6.IPv6Address;
-import com.googlecode.ipv6.IPv6Network;
-import net.arin.rdap_bootstrap.service.JsonBootstrapFile.ServiceUrls;
-import net.arin.rdap_bootstrap.service.ResourceFiles.BootFiles;
-import org.xml.sax.Attributes;
-import org.xml.sax.SAXException;
-import org.xml.sax.helpers.DefaultHandler;
-
-import javax.xml.parsers.SAXParser;
-import javax.xml.parsers.SAXParserFactory;
 import java.util.Map;
 import java.util.TreeMap;
+
+import net.arin.rdap_bootstrap.service.JsonBootstrapFile.ServiceUrls;
+import net.arin.rdap_bootstrap.service.ResourceFiles.BootFiles;
+
+import com.googlecode.ipv6.IPv6Address;
+import com.googlecode.ipv6.IPv6Network;
 
 /**
  * @version $Rev$, $Date$

--- a/src/main/java/net/arin/rdap_bootstrap/service/RedirectServlet.java
+++ b/src/main/java/net/arin/rdap_bootstrap/service/RedirectServlet.java
@@ -16,12 +16,23 @@
  */
 package net.arin.rdap_bootstrap.service;
 
-import com.fasterxml.jackson.annotation.JsonInclude.Include;
-import com.fasterxml.jackson.core.util.DefaultPrettyPrinter;
-import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.databind.ObjectWriter;
-import com.googlecode.ipv6.IPv6Address;
-import com.googlecode.ipv6.IPv6Network;
+import java.io.IOException;
+import java.io.OutputStream;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Date;
+import java.util.Map.Entry;
+import java.util.Set;
+import java.util.Timer;
+import java.util.TimerTask;
+import java.util.concurrent.atomic.AtomicLong;
+
+import javax.servlet.ServletConfig;
+import javax.servlet.ServletException;
+import javax.servlet.http.HttpServlet;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
 import net.arin.rdap_bootstrap.Constants;
 import net.arin.rdap_bootstrap.json.Notice;
 import net.arin.rdap_bootstrap.json.Response;
@@ -30,463 +41,381 @@ import net.arin.rdap_bootstrap.service.JsonBootstrapFile.ServiceUrls;
 import net.arin.rdap_bootstrap.service.ResourceFiles.BootFiles;
 import net.arin.rdap_bootstrap.service.Statistics.UrlHits;
 
-import javax.servlet.ServletConfig;
-import javax.servlet.ServletException;
-import javax.servlet.http.HttpServlet;
-import javax.servlet.http.HttpServletRequest;
-import javax.servlet.http.HttpServletResponse;
-import java.io.IOException;
-import java.io.OutputStream;
-import java.util.*;
-import java.util.Map.Entry;
-import java.util.concurrent.atomic.AtomicLong;
+import com.fasterxml.jackson.annotation.JsonInclude.Include;
+import com.fasterxml.jackson.core.util.DefaultPrettyPrinter;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.ObjectWriter;
+import com.googlecode.ipv6.IPv6Address;
+import com.googlecode.ipv6.IPv6Network;
 
 /**
  * @version $Rev$, $Date$
  */
-public class RedirectServlet extends HttpServlet
-{
-    private AsBootstrap asBootstrap           = new AsBootstrap();
-    private IpV6Bootstrap ipV6Bootstrap       = new IpV6Bootstrap();
-    private IpV4Bootstrap ipV4Bootstrap       = new IpV4Bootstrap();
-    private DomainBootstrap domainBootstrap   = new DomainBootstrap();
-    private DefaultBootstrap defaultBootstrap = new DefaultBootstrap();
-    private EntityBootstrap entityBootstrap   = new EntityBootstrap();
+public class RedirectServlet extends HttpServlet {
+	private AsBootstrap asBootstrap = new AsBootstrap();
+	private IpV6Bootstrap ipV6Bootstrap = new IpV6Bootstrap();
+	private IpV4Bootstrap ipV4Bootstrap = new IpV4Bootstrap();
+	private DomainBootstrap domainBootstrap = new DomainBootstrap();
+	private DefaultBootstrap defaultBootstrap = new DefaultBootstrap();
+	private EntityBootstrap entityBootstrap = new EntityBootstrap();
 
-    private volatile Statistics statistics;
+	private volatile Statistics statistics;
 
-    private ResourceFiles resourceFiles;
-    private Timer timer;
-    Boolean matchSchemeOnRedirect = Boolean.FALSE;
+	private ResourceFiles resourceFiles;
+	private Timer timer;
+	Boolean matchSchemeOnRedirect = Boolean.FALSE;
 
-    private static final long CHECK_CONFIG_FILES = 60000L;
-    static final String MATCH_SCHEME_ON_REDIRECT = "match_scheme_on_redirect";
+	private static final long CHECK_CONFIG_FILES = 60000L;
+	static final String MATCH_SCHEME_ON_REDIRECT = "match_scheme_on_redirect";
 
-    @Override
-    public void init( ServletConfig config ) throws ServletException
-    {
-        super.init( config );
+	@Override
+	public void init(ServletConfig config) throws ServletException {
+		super.init(config);
 
-        statistics = new Statistics();
+		statistics = new Statistics();
 
-        matchSchemeOnRedirect = Boolean.valueOf(
-            System.getProperty( Constants.PROPERTY_PREFIX + MATCH_SCHEME_ON_REDIRECT, matchSchemeOnRedirect.toString() ) );
+		matchSchemeOnRedirect = Boolean.valueOf(System.getProperty(Constants.PROPERTY_PREFIX + MATCH_SCHEME_ON_REDIRECT, matchSchemeOnRedirect.toString()));
 
-        try
-        {
-            LoadConfigTask loadConfigTask = new LoadConfigTask();
-            loadConfigTask.loadData();
+		try {
+			LoadConfigTask loadConfigTask = new LoadConfigTask();
+			loadConfigTask.loadData();
 
-            if( config != null )
-            {
-                timer = new Timer(  );
-                timer.schedule( loadConfigTask, CHECK_CONFIG_FILES, CHECK_CONFIG_FILES );
-            }
-        }
-        catch ( Exception e )
-        {
-            throw new ServletException( e );
-        }
-    }
+			if (config != null) {
+				timer = new Timer();
+				timer.schedule(loadConfigTask, CHECK_CONFIG_FILES, CHECK_CONFIG_FILES);
+			}
+		} catch (Exception e) {
+			throw new ServletException(e);
+		}
+	}
 
-    protected void serve( UrlHits urlHits, BaseMaker baseMaker, DefaultBootstrap.Type defaultType, String pathInfo,
-                          HttpServletRequest req, HttpServletResponse resp )
-        throws IOException
-    {
-        try
-        {
-            UrlHits hits = urlHits;
-            ServiceUrls urls = baseMaker.makeBase( pathInfo );
-            if( urls == null && defaultType != null )
-            {
-                urls = defaultBootstrap.getServiceUrls( defaultType );
-                hits = UrlHits.DEFAULTHITS;
-            }
-            if( urls == null )
-            {
-                resp.sendError( HttpServletResponse.SC_NOT_FOUND );
-                statistics.getTotalMisses().incrementAndGet();
-            }
-            else
-            {
-                String redirectUrl = getRedirectUrl( req.getScheme(),req.getPathInfo(), urls );
-                if( hits != null )
-                {
-                    hits.hit( redirectUrl );
-                }
-                statistics.getTotalHits().incrementAndGet();
-                resp.sendRedirect( redirectUrl );
-            }
-        }
-        catch ( Exception e )
-        {
-            resp.sendError( HttpServletResponse.SC_BAD_REQUEST, e.getMessage() );
-        }
+	protected void serve(UrlHits urlHits, BaseMaker baseMaker, DefaultBootstrap.Type defaultType, String pathInfo, HttpServletRequest req, HttpServletResponse resp) throws IOException {
+		try {
+			UrlHits hits = urlHits;
+			ServiceUrls urls = baseMaker.makeBase(pathInfo);
+			if (urls == null && defaultType != null) {
+				urls = defaultBootstrap.getServiceUrls(defaultType);
+				hits = UrlHits.DEFAULTHITS;
+			}
+			if (urls == null) {
+				resp.sendError(HttpServletResponse.SC_NOT_FOUND);
+				statistics.getTotalMisses().incrementAndGet();
+			} else {
+				String redirectUrl = getRedirectUrl(req.getScheme(), req.getPathInfo(), urls);
+				if (hits != null) {
+					hits.hit(redirectUrl);
+				}
+				statistics.getTotalHits().incrementAndGet();
+				resp.sendRedirect(redirectUrl);
+			}
+		} catch (Exception e) {
+			resp.sendError(HttpServletResponse.SC_BAD_REQUEST, e.getMessage());
+		}
 
-    }
+	}
 
-    String getRedirectUrl( String scheme, String pathInfo, ServiceUrls urls )
-    {
-        String redirectUrl = null;
-        if( matchSchemeOnRedirect )
-        {
-            System.out.println( "matching scheme on redirect" );
-            System.out.println( "https=" + urls.getHttpsUrl() );
-            System.out.println( "http=" + urls.getHttpUrl() );
-            System.out.println( "scheme=" + scheme );
-            if( scheme.equals( "https" ) && urls.getHttpsUrl() != null )
-            {
-                redirectUrl = urls.getHttpsUrl() + pathInfo;
-                System.out.println( "https redirect=" + redirectUrl );
-            }
-            else if( scheme.equals( "http" ) && urls.getHttpUrl() != null )
-            {
-                redirectUrl = urls.getHttpUrl() + pathInfo;
-                System.out.println( "http redirect=" + redirectUrl );
-            }
-            else
-            {
-                redirectUrl = urls.getUrls().get( 0 ) + pathInfo;
-                System.out.println( "default redirect=" + redirectUrl );
-            }
-        }
-        else
-        {
-            redirectUrl = urls.getHttpsUrl();
-            if( redirectUrl == null )
-            {
-                redirectUrl = urls.getHttpUrl();
-            }
-            if( redirectUrl != null )
-            {
-                redirectUrl += pathInfo;
-            }
-        }
-        return redirectUrl;
-    }
+	String getRedirectUrl(String scheme, String pathInfo, ServiceUrls urls) {
+		String redirectUrl = null;
+		if (matchSchemeOnRedirect) {
+			System.out.println("matching scheme on redirect");
+			System.out.println("https=" + urls.getHttpsUrl());
+			System.out.println("http=" + urls.getHttpUrl());
+			System.out.println("scheme=" + scheme);
+			if (scheme.equals("https") && urls.getHttpsUrl() != null) {
+				redirectUrl = urls.getHttpsUrl() + pathInfo;
+				System.out.println("https redirect=" + redirectUrl);
+			} else if (scheme.equals("http") && urls.getHttpUrl() != null) {
+				redirectUrl = urls.getHttpUrl() + pathInfo;
+				System.out.println("http redirect=" + redirectUrl);
+			} else {
+				redirectUrl = urls.getUrls().get(0) + pathInfo;
+				System.out.println("default redirect=" + redirectUrl);
+			}
+		} else {
+			redirectUrl = urls.getHttpsUrl();
+			if (redirectUrl == null) {
+				redirectUrl = urls.getHttpUrl();
+			}
+			if (redirectUrl != null) {
+				redirectUrl += pathInfo;
+			}
+		}
+		return redirectUrl;
+	}
 
-    @Override
-    protected void service( HttpServletRequest req, HttpServletResponse resp )
-        throws ServletException, IOException
-    {
-        String pathInfo = req.getPathInfo();
-        if( pathInfo.startsWith( "/domain/" ) )
-        {
-            serve( UrlHits.DOMAINHITS, new MakeDomainBase(), Type.DOMAIN, pathInfo, req, resp );
-        }
-        else if( pathInfo.startsWith( "/nameserver/" ) )
-        {
-            serve( UrlHits.NAMESERVERHITS, new MakeNameserverBase(), Type.NAMESERVER, pathInfo, req, resp );
-        }
-        else if( pathInfo.startsWith( "/ip/" ) )
-        {
-            serve( UrlHits.IPHITS, new MakeIpBase(), Type.IP, pathInfo, req, resp );
-        }
-        else if( pathInfo.startsWith( "/entity/" ) )
-        {
-            serve( UrlHits.ENTITYHITS, new MakeEntityBase(), Type.ENTITY, pathInfo, req, resp );
-        }
-        else if( pathInfo.startsWith( "/autnum/" ) )
-        {
-            serve( UrlHits.ASHITS, new MakeAutnumBase(), Type.AUTNUM, pathInfo, req, resp );
-        }
-        else if( pathInfo.startsWith( "/help" ) )
-        {
-            resp.setContentType( "application/rdap+json" );
-            makeHelp( resp.getOutputStream() );
-        }
-        else
-        {
-            resp.sendError( HttpServletResponse.SC_NOT_FOUND );
-        }
-    }
+	@Override
+	protected void service(HttpServletRequest req, HttpServletResponse resp) throws ServletException, IOException {
+		String pathInfo = req.getPathInfo();
+		if (pathInfo.startsWith("/domain/")) {
+			serve(UrlHits.DOMAINHITS, new MakeDomainBase(), Type.DOMAIN, pathInfo, req, resp);
+		} else if (pathInfo.startsWith("/nameserver/")) {
+			serve(UrlHits.NAMESERVERHITS, new MakeNameserverBase(), Type.NAMESERVER, pathInfo, req, resp);
+		} else if (pathInfo.startsWith("/ip/")) {
+			serve(UrlHits.IPHITS, new MakeIpBase(), Type.IP, pathInfo, req, resp);
+		} else if (pathInfo.startsWith("/entity/")) {
+			serve(UrlHits.ENTITYHITS, new MakeEntityBase(), Type.ENTITY, pathInfo, req, resp);
+		} else if (pathInfo.startsWith("/autnum/")) {
+			serve(UrlHits.ASHITS, new MakeAutnumBase(), Type.AUTNUM, pathInfo, req, resp);
+		} else if (pathInfo.startsWith("/help")) {
+			resp.setContentType("application/rdap+json");
+			makeHelp(resp.getOutputStream());
+		} else {
+			resp.sendError(HttpServletResponse.SC_NOT_FOUND);
+		}
+	}
 
-    public interface BaseMaker
-    {
-        public ServiceUrls makeBase( String pathInfo );
-    }
+	public interface BaseMaker {
+		public ServiceUrls makeBase(String pathInfo);
+	}
 
-    public ServiceUrls makeAutnumBase( String pathInfo )
-    {
-        return new MakeAutnumBase().makeBase( pathInfo );
-    }
+	public ServiceUrls makeAutnumBase(String pathInfo) {
+		return new MakeAutnumBase().makeBase(pathInfo);
+	}
 
-    public class MakeAutnumBase implements BaseMaker
-    {
-        public ServiceUrls makeBase( String pathInfo )
-        {
-            return asBootstrap.getServiceUrls( pathInfo.split( "/" )[2] );
-        }
-    }
+	public class MakeAutnumBase implements BaseMaker {
+		public ServiceUrls makeBase(String pathInfo) {
+			return asBootstrap.getServiceUrls(pathInfo.split("/")[2]);
+		}
+	}
 
-    public ServiceUrls makeIpBase( String pathInfo )
-    {
-        return new MakeIpBase().makeBase( pathInfo );
-    }
+	public ServiceUrls makeIpBase(String pathInfo) {
+		return new MakeIpBase().makeBase(pathInfo);
+	}
 
-    public class MakeIpBase implements BaseMaker
-    {
-        public ServiceUrls makeBase( String pathInfo )
-        {
-            //strip leading "/ip/"
-            pathInfo = pathInfo.substring( 4 );
-            if( pathInfo.indexOf( ":" ) == -1 ) //is not ipv6
-            {
-                String firstOctet = pathInfo.split( "\\." )[ 0 ];
-                return ipV4Bootstrap.getServiceUrls( Integer.parseInt( firstOctet ) );
-            }
-            //else
-            IPv6Address addr = null;
-            if( pathInfo.indexOf( "/" ) == -1 )
-            {
-                addr = IPv6Address.fromString( pathInfo );
-            }
-            else
-            {
-                IPv6Network net = IPv6Network.fromString( pathInfo );
-                addr = net.getFirst();
-            }
-            return ipV6Bootstrap.getServiceUrls( addr );
-        }
-    }
+	public class MakeIpBase implements BaseMaker {
+		public ServiceUrls makeBase(String pathInfo) {
+			// strip leading "/ip/"
+			pathInfo = pathInfo.substring(4);
+			if (pathInfo.indexOf(":") == -1) // is not ipv6
+			{
+				// String firstOctet = pathInfo.split( "\\." )[ 0 ];
+				return ipV4Bootstrap.getServiceUrls(pathInfo);
+			}
+			// else
+			IPv6Address addr = null;
+			if (pathInfo.indexOf("/") == -1) {
+				addr = IPv6Address.fromString(pathInfo);
+			} else {
+				IPv6Network net = IPv6Network.fromString(pathInfo);
+				addr = net.getFirst();
+			}
+			return ipV6Bootstrap.getServiceUrls(addr);
+		}
+	}
 
-    public ServiceUrls makeDomainBase( String pathInfo )
-    {
-        return new MakeDomainBase().makeBase( pathInfo );
-    }
+	public ServiceUrls makeDomainBase(String pathInfo) {
+		return new MakeDomainBase().makeBase(pathInfo);
+	}
 
-    public class MakeDomainBase implements BaseMaker
-    {
-        public ServiceUrls makeBase( String pathInfo )
-        {
-            //strip leading "/domain/"
-            pathInfo = pathInfo.substring( 8 );
-            //strip possible trailing period
-            if( pathInfo.endsWith( "." ) )
-            {
-                pathInfo = pathInfo.substring( 0, pathInfo.length() - 1 );
-            }
-            if( pathInfo.endsWith( ".in-addr.arpa" ) )
-            {
-                String[] labels = pathInfo.split( "\\." );
-                String firstOctet = labels[ labels.length -3 ];
-                return ipV4Bootstrap.getServiceUrls( Integer.parseInt( firstOctet ) );
-            }
-            else if( pathInfo.endsWith( ".ip6.arpa" ) )
-            {
-                String[] labels = pathInfo.split( "\\." );
-                byte[] bytes = new byte[ 16 ];
-                Arrays.fill( bytes, ( byte ) 0 );
-                int labelIdx = labels.length -3;
-                int byteIdx = 0;
-                int idxJump = 1;
-                while( labelIdx > 0 )
-                {
-                    char ch = labels[ labelIdx ].charAt( 0 );
-                    byte value = 0;
-                    if( ch >= '0' && ch <= '9' )
-                    {
-                        value = (byte)(ch - '0');
-                    }
-                    else if (ch >= 'A' && ch <= 'F' )
-                    {
-                        value = (byte)(ch - ( 'A' - 0xaL ) );
-                    }
-                    else if (ch >= 'a' && ch <= 'f' )
-                    {
-                        value = (byte)(ch - ( 'a' - 0xaL ) );
-                    }
-                    if( idxJump % 2 == 1 )
-                    {
-                        bytes[ byteIdx ] = ( byte ) (value << 4);
-                    }
-                    else
-                    {
-                        bytes[ byteIdx ] = ( byte ) (bytes[ byteIdx ] + value);
-                    }
-                    labelIdx--;
-                    idxJump++;
-                    if( idxJump % 2 == 1 )
-                    {
-                        byteIdx++;
-                    }
-                }
-                return ipV6Bootstrap.getServiceUrls( IPv6Address.fromByteArray( bytes ) );
-            }
-            //else
-            String[] labels = pathInfo.split( "\\." );
-            return domainBootstrap.getServiceUrls( labels[labels.length - 1] );
-        }
+	public class MakeDomainBase implements BaseMaker {
+		public ServiceUrls makeBase(String pathInfo) {
+			// strip leading "/domain/"
+			pathInfo = pathInfo.substring(8);
+			// strip possible trailing period
+			if (pathInfo.endsWith(".")) {
+				pathInfo = pathInfo.substring(0, pathInfo.length() - 1);
+			}
+			if (pathInfo.endsWith(".in-addr.arpa")) {
+				final int BITS_PER_WORD = 8, MIVAR = 1;
+				final String DELIMITER = ".";
 
-    }
+				String[] words = new String[4];
+				Arrays.fill(words, "0");
 
-    public ServiceUrls makeNameserverBase( String pathInfo )
-    {
-        return new MakeNameserverBase().makeBase( pathInfo );
-    }
+				final String[] _split = pathInfo.split("\\.");
+				int n = _split.length - 2;
 
-    public class MakeNameserverBase implements BaseMaker
-    {
-        public ServiceUrls makeBase( String pathInfo )
-        {
-            //strip leading "/nameserver/"
-            pathInfo = pathInfo.substring( 12 );
-            //strip possible trailing period
-            if( pathInfo.endsWith( "." ) )
-            {
-                pathInfo = pathInfo.substring( 0, pathInfo.length() - 1 );
-            }
-            String[] labels = pathInfo.split( "\\." );
-            return domainBootstrap.getServiceUrls( labels[labels.length - 1] );
-        }
-    }
+				String s = "", _s = "";
+				for (int i = n - 1, j = 1; i >= 0; i--, j++) {
+					_s += _split[i];
+					if (j % MIVAR == 0) {
+						words[j / MIVAR - 1] = _s;// índice posicional
+						_s = "";
+					}
+				}
 
-    public ServiceUrls makeEntityBase( String pathInfo )
-    {
-        return new MakeEntityBase().makeBase( pathInfo );
-    }
+				for (int i = 0; i < words.length - 1; i++) {// todos menos el
+															// último
+					s += words[i] + DELIMITER;
+				}
+				s += words[words.length - 1];// el último sin DELIMITER
+				s += "/" + BITS_PER_WORD * n;
 
-    public class MakeEntityBase implements BaseMaker
-    {
-        public ServiceUrls makeBase( String pathInfo )
-        {
-            int i = pathInfo.lastIndexOf( '-' );
-            if( i != -1 && i + 1 < pathInfo.length() )
-            {
-                return entityBootstrap.getServiceUrls( pathInfo.substring( i + 1 ) );
-            }
-            //else
-            return null;
-        }
+				return ipV4Bootstrap.getServiceUrls(s);
 
-    }
+			} else if (pathInfo.endsWith(".ip6.arpa")) {
+				String[] labels = pathInfo.split("\\.");
+				byte[] bytes = new byte[16];
+				Arrays.fill(bytes, (byte) 0);
+				int labelIdx = labels.length - 3;
+				int byteIdx = 0;
+				int idxJump = 1;
+				while (labelIdx > 0) {
+					char ch = labels[labelIdx].charAt(0);
+					byte value = 0;
+					if (ch >= '0' && ch <= '9') {
+						value = (byte) (ch - '0');
+					} else if (ch >= 'A' && ch <= 'F') {
+						value = (byte) (ch - ('A' - 0xaL));
+					} else if (ch >= 'a' && ch <= 'f') {
+						value = (byte) (ch - ('a' - 0xaL));
+					}
+					if (idxJump % 2 == 1) {
+						bytes[byteIdx] = (byte) (value << 4);
+					} else {
+						bytes[byteIdx] = (byte) (bytes[byteIdx] + value);
+					}
+					labelIdx--;
+					idxJump++;
+					if (idxJump % 2 == 1) {
+						byteIdx++;
+					}
+				}
+				return ipV6Bootstrap.getServiceUrls(IPv6Address.fromByteArray(bytes));
+			}
+			// else
+			String[] labels = pathInfo.split("\\.");
+			return domainBootstrap.getServiceUrls(labels[labels.length - 1]);
+		}
 
-    private Notice makeStatsNotice( Statistics.UrlHits stats )
-    {
-        Notice notice = new Notice();
-        notice.setTitle( stats.getTitle() );
-        ArrayList<String> description = new ArrayList<String>(  );
-        Set<Entry<String,AtomicLong>> entrySet = stats.getEntrySet();
-        if( entrySet.size() != 0 )
-        {
-            for ( Entry<String, AtomicLong> entry : entrySet )
-            {
-                description.add(
-                    String.format( "%-5d = %25s", entry.getValue().get(), entry.getKey() ) );
-            }
-        }
-        else
-        {
-            description.add( "Zero queries." );
-        }
-        notice.setDescription( description.toArray( new String[ description.size() ] ) );
-        return notice;
-    }
+	}
 
-    public void makeHelp( OutputStream outputStream ) throws IOException
-    {
-        Response response = new Response( null );
-        ArrayList<Notice> notices = new ArrayList<Notice>();
+	public ServiceUrls makeNameserverBase(String pathInfo) {
+		return new MakeNameserverBase().makeBase(pathInfo);
+	}
 
-        //do statistics
-        for( Statistics.UrlHits stats: Statistics.UrlHits.values() )
-        {
-            notices.add(makeStatsNotice( stats ) );
-        }
+	public class MakeNameserverBase implements BaseMaker {
+		public ServiceUrls makeBase(String pathInfo) {
+			// strip leading "/nameserver/"
+			pathInfo = pathInfo.substring(12);
+			// strip possible trailing period
+			if (pathInfo.endsWith(".")) {
+				pathInfo = pathInfo.substring(0, pathInfo.length() - 1);
+			}
+			String[] labels = pathInfo.split("\\.");
+			return domainBootstrap.getServiceUrls(labels[labels.length - 1]);
+		}
+	}
 
-        //totals
-        Notice notice = new Notice();
-        notice.setTitle( "Totals" );
-        String[] description = new String[ 2 ];
-        description[ 0 ] = String.format( "Hits   = %5d", statistics.getTotalHits().get() );
-        description[ 1 ] = String.format( "Misses = %5d", statistics.getTotalMisses().get() );
-        notice.setDescription( description );
-        notices.add( notice );
+	public ServiceUrls makeEntityBase(String pathInfo) {
+		return new MakeEntityBase().makeBase(pathInfo);
+	}
 
-        // Modified dates for various bootstrap files, done this way so that Publication dates can be published as well.
-        notices.add( createPublicationDateNotice("Default", resourceFiles.getLastModified(BootFiles.DEFAULT.getKey()), defaultBootstrap.getPublication()) );
-        notices.add( createPublicationDateNotice("As", resourceFiles.getLastModified(BootFiles.AS.getKey()), asBootstrap.getPublication()) );
-        notices.add( createPublicationDateNotice("Domain", resourceFiles.getLastModified(BootFiles.DOMAIN.getKey()), domainBootstrap.getPublication()) );
-        notices.add( createPublicationDateNotice("Entity", resourceFiles.getLastModified(BootFiles.ENTITY.getKey()), entityBootstrap.getPublication()) );
-        notices.add( createPublicationDateNotice("IpV4", resourceFiles.getLastModified(BootFiles.V4.getKey()), ipV4Bootstrap.getPublication()) );
-        notices.add( createPublicationDateNotice( "IpV6",
-            resourceFiles.getLastModified( BootFiles.V6.getKey() ),
-            ipV6Bootstrap.getPublication() ) );
+	public class MakeEntityBase implements BaseMaker {
+		public ServiceUrls makeBase(String pathInfo) {
+			int i = pathInfo.lastIndexOf('-');
+			if (i != -1 && i + 1 < pathInfo.length()) {
+				return entityBootstrap.getServiceUrls(pathInfo.substring(i + 1));
+			}
+			// else
+			return null;
+		}
 
-        response.setNotices( notices );
+	}
 
-        ObjectMapper mapper = new ObjectMapper();
-        mapper.setSerializationInclusion( Include.NON_EMPTY );
-        ObjectWriter writer = mapper.writer( new DefaultPrettyPrinter(  ) );
-        writer.writeValue( outputStream, response );
-    }
+	private Notice makeStatsNotice(Statistics.UrlHits stats) {
+		Notice notice = new Notice();
+		notice.setTitle(stats.getTitle());
+		ArrayList<String> description = new ArrayList<String>();
+		Set<Entry<String, AtomicLong>> entrySet = stats.getEntrySet();
+		if (entrySet.size() != 0) {
+			for (Entry<String, AtomicLong> entry : entrySet) {
+				description.add(String.format("%-5d = %25s", entry.getValue().get(), entry.getKey()));
+			}
+		} else {
+			description.add("Zero queries.");
+		}
+		notice.setDescription(description.toArray(new String[description.size()]));
+		return notice;
+	}
 
-    private Notice createPublicationDateNotice(String file, long lastModified, String publicationDate)
-    {
-        Notice bootFileModifiedNotice = new Notice();
+	public void makeHelp(OutputStream outputStream) throws IOException {
+		Response response = new Response(null);
+		ArrayList<Notice> notices = new ArrayList<Notice>();
 
-        bootFileModifiedNotice.setTitle( String.format("%s Bootstrap File Modified and Published Dates", file) );
-        String[] bootFileModifiedDescription = new String[ 2 ];
-        // Date format as 2015-05-15T17:04:06-0500 (Y-m-d'T'H:M:Sz)
-        bootFileModifiedDescription[0] = String.format( "%1$tFT%1$tT%1$tz", lastModified );
-        bootFileModifiedDescription[1] = publicationDate;
-        bootFileModifiedNotice.setDescription( bootFileModifiedDescription );
+		// do statistics
+		for (Statistics.UrlHits stats : Statistics.UrlHits.values()) {
+			notices.add(makeStatsNotice(stats));
+		}
 
-        return bootFileModifiedNotice;
-    }
+		// totals
+		Notice notice = new Notice();
+		notice.setTitle("Totals");
+		String[] description = new String[2];
+		description[0] = String.format("Hits   = %5d", statistics.getTotalHits().get());
+		description[1] = String.format("Misses = %5d", statistics.getTotalMisses().get());
+		notice.setDescription(description);
+		notices.add(notice);
 
-    private class LoadConfigTask extends TimerTask
-    {
-        private boolean isModified( long currentTime, long lastModified )
-        {
-            if( ( currentTime - CHECK_CONFIG_FILES ) < lastModified )
-            {
-                return true;
-            }
-            //else
-            return false;
-        }
+		// Modified dates for various bootstrap files, done this way so that
+		// Publication dates can be published as well.
+		notices.add(createPublicationDateNotice("Default", resourceFiles.getLastModified(BootFiles.DEFAULT.getKey()), defaultBootstrap.getPublication()));
+		notices.add(createPublicationDateNotice("As", resourceFiles.getLastModified(BootFiles.AS.getKey()), asBootstrap.getPublication()));
+		notices.add(createPublicationDateNotice("Domain", resourceFiles.getLastModified(BootFiles.DOMAIN.getKey()), domainBootstrap.getPublication()));
+		notices.add(createPublicationDateNotice("Entity", resourceFiles.getLastModified(BootFiles.ENTITY.getKey()), entityBootstrap.getPublication()));
+		notices.add(createPublicationDateNotice("IpV4", resourceFiles.getLastModified(BootFiles.V4.getKey()), ipV4Bootstrap.getPublication()));
+		notices.add(createPublicationDateNotice("IpV6", resourceFiles.getLastModified(BootFiles.V6.getKey()), ipV6Bootstrap.getPublication()));
 
-        @Override
-        public void run()
-        {
-            boolean load = false;
-            long currentTime = System.currentTimeMillis();
-            for ( BootFiles bootFiles : BootFiles.values() )
-            {
-               if( isModified( currentTime, resourceFiles.getLastModified( bootFiles.getKey() ) ) )
-               {
-                   getServletContext().log( String.format("%s was last modified at %s",
-                           bootFiles.getKey(), new Date(resourceFiles.getLastModified(bootFiles.getKey()))) );
-                   load = true;
-               }
-            }
-            if( load )
-            {
-                try
-                {
-                    loadData();
-                }
-                catch ( Exception e )
-                {
-                    getServletContext().log( "Problem loading config", e );
-                }
-            }
-        }
+		response.setNotices(notices);
 
-        public void loadData() throws Exception
-        {
-            if( getServletConfig() != null )
-            {
-                getServletContext().log( "Loading resource files." );
-            }
-            resourceFiles = new ResourceFiles();
-            asBootstrap.loadData( resourceFiles );
-            ipV4Bootstrap.loadData( resourceFiles );
-            ipV6Bootstrap.loadData( resourceFiles );
-            domainBootstrap.loadData( resourceFiles );
-            entityBootstrap.loadData( resourceFiles );
-            defaultBootstrap.loadData( resourceFiles );
-        }
-    }
+		ObjectMapper mapper = new ObjectMapper();
+		mapper.setSerializationInclusion(Include.NON_EMPTY);
+		ObjectWriter writer = mapper.writer(new DefaultPrettyPrinter());
+		writer.writeValue(outputStream, response);
+	}
+
+	private Notice createPublicationDateNotice(String file, long lastModified, String publicationDate) {
+		Notice bootFileModifiedNotice = new Notice();
+
+		bootFileModifiedNotice.setTitle(String.format("%s Bootstrap File Modified and Published Dates", file));
+		String[] bootFileModifiedDescription = new String[2];
+		// Date format as 2015-05-15T17:04:06-0500 (Y-m-d'T'H:M:Sz)
+		bootFileModifiedDescription[0] = String.format("%1$tFT%1$tT%1$tz", lastModified);
+		bootFileModifiedDescription[1] = publicationDate;
+		bootFileModifiedNotice.setDescription(bootFileModifiedDescription);
+
+		return bootFileModifiedNotice;
+	}
+
+	private class LoadConfigTask extends TimerTask {
+		private boolean isModified(long currentTime, long lastModified) {
+			if ((currentTime - CHECK_CONFIG_FILES) < lastModified) {
+				return true;
+			}
+			// else
+			return false;
+		}
+
+		@Override
+		public void run() {
+			boolean load = false;
+			long currentTime = System.currentTimeMillis();
+			for (BootFiles bootFiles : BootFiles.values()) {
+				if (isModified(currentTime, resourceFiles.getLastModified(bootFiles.getKey()))) {
+					getServletContext().log(String.format("%s was last modified at %s", bootFiles.getKey(), new Date(resourceFiles.getLastModified(bootFiles.getKey()))));
+					load = true;
+				}
+			}
+			if (load) {
+				try {
+					loadData();
+				} catch (Exception e) {
+					getServletContext().log("Problem loading config", e);
+				}
+			}
+		}
+
+		public void loadData() throws Exception {
+			if (getServletConfig() != null) {
+				getServletContext().log("Loading resource files.");
+			}
+			resourceFiles = new ResourceFiles();
+			asBootstrap.loadData(resourceFiles);
+			ipV4Bootstrap.loadData(resourceFiles);
+			ipV6Bootstrap.loadData(resourceFiles);
+			domainBootstrap.loadData(resourceFiles);
+			entityBootstrap.loadData(resourceFiles);
+			defaultBootstrap.loadData(resourceFiles);
+		}
+	}
 }

--- a/src/test/java/net/arin/rdap_bootstrap/service/DefaultBootstrapTest.java
+++ b/src/test/java/net/arin/rdap_bootstrap/service/DefaultBootstrapTest.java
@@ -32,8 +32,7 @@ public class DefaultBootstrapTest
         DefaultBootstrap d = new DefaultBootstrap();
         d.loadData( new ResourceFiles() );
 
-        assertEquals( "http://rdap.arin.net/registry",
-            d.getServiceUrls( Type.AUTNUM ).getHttpUrl() );
+        assertEquals( "http://rdap.arin.net/registry", d.getServiceUrls( Type.AUTNUM ).getHttpUrl() );
         assertEquals( "http://rdg.afilias.info/rdap", d.getServiceUrls( Type.DOMAIN ).getHttpUrl() );
     }
 }

--- a/src/test/java/net/arin/rdap_bootstrap/service/IpV4BootstrapTest.java
+++ b/src/test/java/net/arin/rdap_bootstrap/service/IpV4BootstrapTest.java
@@ -46,5 +46,6 @@ public class IpV4BootstrapTest
         
         // Testing for host addresses
         assertEquals( "https://rdap.lacnic.net/rdap", v4.getServiceUrls( "177.0.0.1/32" ).getHttpsUrl() );
+        assertEquals( "https://rdap.lacnic.net/rdap", v4.getServiceUrls( "177.0.0.1" ).getHttpsUrl() );
     }
 }

--- a/src/test/java/net/arin/rdap_bootstrap/service/IpV4BootstrapTest.java
+++ b/src/test/java/net/arin/rdap_bootstrap/service/IpV4BootstrapTest.java
@@ -16,10 +16,9 @@
  */
 package net.arin.rdap_bootstrap.service;
 
-import org.junit.Test;
-
 import static junit.framework.Assert.assertEquals;
-import static junit.framework.Assert.assertNull;
+
+import org.junit.Test;
 
 /**
  * @version $Rev$, $Date$
@@ -31,16 +30,21 @@ public class IpV4BootstrapTest
     {
         IpV4Bootstrap v4 = new IpV4Bootstrap();
         v4.loadData( new ResourceFiles() );
-
-        assertEquals( "https://rdap.apnic.net", v4.getServiceUrls( 1 ).getHttpsUrl() );
+        
+        assertEquals( "https://rdap.apnic.net", v4.getServiceUrls( "1" ).getHttpsUrl() );
         //TODO renable when their server are put back in the bootstrap files
         //assertEquals( "http://rdap.iana.org", v4.getServiceUrls( 0 ).getHttpUrl() );
-        assertEquals( "https://rdap.apnic.net", v4.getServiceUrls( 27 ).getHttpsUrl() );
-        assertEquals( "https://rdap.db.ripe.net", v4.getServiceUrls( 31 ).getHttpsUrl() );
-        assertEquals( "http://rdap.afrinic.net/rdap", v4.getServiceUrls( 41 ).getHttpUrl() );
-        assertEquals( "https://rdap.lacnic.net/rdap", v4.getServiceUrls( 177 ).getHttpsUrl() );
-        assertEquals( "https://rdap.db.ripe.net", v4.getServiceUrls( 188 ).getHttpsUrl() );
-        assertEquals( "https://rdap.lacnic.net/rdap", v4.getServiceUrls( 191 ).getHttpsUrl() );
+        assertEquals( "https://rdap.apnic.net", v4.getServiceUrls( "27" ).getHttpsUrl() );
+        assertEquals( "https://rdap.db.ripe.net", v4.getServiceUrls( "31" ).getHttpsUrl() );
+        assertEquals( "http://rdap.afrinic.net/rdap", v4.getServiceUrls( "41" ).getHttpUrl() );
+        assertEquals( "https://rdap.lacnic.net/rdap", v4.getServiceUrls( "177" ).getHttpsUrl() );
+        assertEquals( "https://rdap.db.ripe.net", v4.getServiceUrls( "188" ).getHttpsUrl() );
+        assertEquals( "https://rdap.lacnic.net/rdap", v4.getServiceUrls( "191" ).getHttpsUrl() );
+        
+        // Testing for full prefixes
+        assertEquals( "https://rdap.lacnic.net/rdap", v4.getServiceUrls( "177.0.0.0/8" ).getHttpsUrl() );
+        
+        // Testing for host addresses
+        assertEquals( "https://rdap.lacnic.net/rdap", v4.getServiceUrls( "177.0.0.1/32" ).getHttpsUrl() );
     }
-
 }

--- a/src/test/java/net/arin/rdap_bootstrap/service/RedirectServletTest.java
+++ b/src/test/java/net/arin/rdap_bootstrap/service/RedirectServletTest.java
@@ -176,13 +176,15 @@ public class RedirectServletTest
         assertEquals( ARIN, servlet.makeIpBase( "/ip/7.0.0.0/8" ).getHttpUrl() );
         assertEquals( ARIN, servlet.makeIpBase( "/ip/7.0.0.0/16" ).getHttpUrl() );
         assertEquals( LACNIC, servlet.makeIpBase( "/ip/191.0.1.0/24" ).getHttpsUrl() );
-        assertEquals( LACNIC, servlet.makeIpBase( "/ip/191.0.1.0/24" ).getHttpsUrl() );
         assertEquals( ARIN, servlet.makeIpBase( "/ip/2620:0000:0000:0000:0000:0000:0000:0000" ).getHttpUrl() );
         //TODO renable when their server are put back in the bootstrap files
         //assertEquals( AFRINIC, servlet.makeIpBase( "/ip/2c00:0000::/12" ).getHttpUrl() );
         assertEquals( LACNIC, servlet.makeIpBase( "/ip/2800:0000::/12" ).getHttpsUrl() );
         //TODO renable when their server are put back in the bootstrap files
         //assertEquals( IANA, servlet.makeIpBase( "/ip/2001:0000::1" ).getHttpUrl() );
+        
+        assertEquals( LACNIC, servlet.makeIpBase( "/ip/191.0.1.1/32" ).getHttpsUrl() );
+        assertEquals( LACNIC, servlet.makeIpBase( "/ip/191.0.1.1" ).getHttpsUrl() );
     }
 
     @Test

--- a/src/test/java/net/arin/rdap_bootstrap/service/RedirectServletTest.java
+++ b/src/test/java/net/arin/rdap_bootstrap/service/RedirectServletTest.java
@@ -173,9 +173,9 @@ public class RedirectServletTest
         RedirectServlet servlet = new RedirectServlet();
         servlet.init( null );
 
-        assertEquals( ARIN, servlet.makeIpBase( "/ip/7.0.0.0" ).getHttpUrl() );
+        assertEquals( ARIN, servlet.makeIpBase( "/ip/7.0.0.0/8" ).getHttpUrl() );
         assertEquals( ARIN, servlet.makeIpBase( "/ip/7.0.0.0/16" ).getHttpUrl() );
-        assertEquals( LACNIC, servlet.makeIpBase( "/ip/191.0.1.0" ).getHttpsUrl() );
+        assertEquals( LACNIC, servlet.makeIpBase( "/ip/191.0.1.0/24" ).getHttpsUrl() );
         assertEquals( LACNIC, servlet.makeIpBase( "/ip/191.0.1.0/24" ).getHttpsUrl() );
         assertEquals( ARIN, servlet.makeIpBase( "/ip/2620:0000:0000:0000:0000:0000:0000:0000" ).getHttpUrl() );
         //TODO renable when their server are put back in the bootstrap files


### PR DESCRIPTION
#### IPv4 queries for longer than /8 prefixes
Implemented the lookup for longer prefixes than /8s by using RIPE's Ip Resource libraries.
This way intersecting blocks can coexist in the same bootstrap file, where the longest prefix is selected. This enables to build a custom bootstrap file containing more information than IANA's (for example NIRs information).

**Performance**
We thought the use RIPE's libs may downgrade performance, as Strings are parsed in every query, but actually it almost didn't.
![Histograms comparing the new branch and the old one](https://cloud.githubusercontent.com/assets/1735250/11964371/ef6ca2be-a8cb-11e5-8cc1-68435ac9d45f.png)